### PR TITLE
feat: add sample_size with default value to ReadJsonOptions

### DIFF
--- a/mad_prefect/data_assets/options.py
+++ b/mad_prefect/data_assets/options.py
@@ -11,6 +11,7 @@ class ReadJsonOptions(BaseModel):
     # By default, always try and parse a nested object as a struct
     field_appearance_threshold: Optional[int] = 0
     map_inference_threshold: Optional[int] = -1
+    sample_size: Optional[int] = -1
     columns: Optional[Dict[str, str]] = None
 
     timestampformat: Optional[str] = None


### PR DESCRIPTION
Add sample size to ReadJsonOptions improve json data type conversion functionality. Setting default value to -1 means entire structure will be scanned to determine data types.