### PR TITLE
feat: add additional read_json options from documentation

### DIFF
--- a/mad_prefect/data_assets/options.py
+++ b/mad_prefect/data_assets/options.py
@@ -12,6 +12,14 @@ class ReadJsonOptions(BaseModel):
     field_appearance_threshold: Optional[int] = 0
     map_inference_threshold: Optional[int] = -1
     sample_size: Optional[int] = -1
-    columns: Optional[Dict[str, str]] = None
 
+    columns: Optional[Dict[str, str]] = None
     timestampformat: Optional[str] = None
+    auto_detect: Optional[bool] = None
+    compression: Optional[str] = None
+    convert_strings_to_integers: Optional[bool] = None
+    dateformat: Optional[str] = None
+    filename: Optional[bool] = None
+    ignore_errors: Optional[bool] = None
+    maximum_depth: Optional[int] = None
+    records: Optional[str] = None


### PR DESCRIPTION
I've add all of the available options from the read_json documentation - setting default values to None for those that we don't need a specific default value for.