### PR TITLE
Feat/multiple file type asset materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ def asset(
     snapshot_artifacts: bool = False,
     artifact_filetype: ARTIFACT_FILE_TYPES = "json",
     read_json_options: ReadJsonOptions | None = None,
+    read_csv_options: ReadCSVOptions | None = None,
     cache_expiration: datetime.timedelta | None = None,
 ):
     ...
@@ -99,11 +100,14 @@ The `asset` decorator is used to define a data asset within a Prefect flow. It w
 **Parameters:**
 
 - `path` (str): The path where the final result artifact will be stored.
+    - Supports multiple file types using a |-delimited syntax 
+    - e.g. "path/to/file.parquet|csv" will produce two result artifacts at "path/to/file.parquet" and "path/to/file.csv"
 - `artifacts_dir` (str, optional): The directory where intermediate artifacts will be stored.
 - `name` (str, optional): The name of the data asset. If not provided, defaults to the function name.
 - `snapshot_artifacts` (bool, optional): Whether to snapshot artifacts over time.
-- `artifact_filetype` (Literal["parquet", "json"], optional): The file type for artifacts.
+- `artifact_filetype` (Literal["parquet", "json", "csv"], optional): The file type for intermediate artifacts.
 - `read_json_options` (ReadJsonOptions, optional): Options for reading JSON data.
+- `read_csv_options` (ReadCSVOptions, optional): Options for reading comma separated values data.
 - `cache_expiration` (datetime.timedelta, optional): The cache expiration time. If data has been materialized within this period, it will be reused.
 
 **Usage:**
@@ -132,6 +136,7 @@ class DataAsset:
         snapshot_artifacts: bool = False,
         artifact_filetype: ARTIFACT_FILE_TYPES = "json",
         read_json_options: ReadJsonOptions | None = None,
+        read_csv_options: ReadCSVOptions | None = None,
         cache_expiration: timedelta | None = None,
     ):
         ...
@@ -150,7 +155,7 @@ The `DataAsset` class represents a data asset in the system. It manages the exec
 
 - `name`: The name of the data asset.
 - `path`: The path where the final result artifact is stored.
-- `artifact_filetype`: The file type for artifacts (e.g., "json", "parquet").
+- `artifact_filetype`: The file type for artifacts (e.g., "json", "parquet", "csv").
 
 ---
 
@@ -165,6 +170,7 @@ class DataArtifact:
         path: str,
         data: object | None = None,
         read_json_options: ReadJsonOptions | None = None,
+        read_csv_options: ReadCSVOptions | None = None,
     ):
         ...
 ```
@@ -196,6 +202,7 @@ class DataArtifactCollector:
         filetype: ARTIFACT_FILE_TYPES = "json",
         artifacts: list[DataArtifact] | None = None,
         read_json_options: ReadJsonOptions | None = None,
+        read_csv_options: ReadCSVOptions | None = None,
     ):
         ...
 ```
@@ -218,6 +225,7 @@ class DataArtifactQuery:
         self,
         artifacts: list[DataArtifact] | None = None,
         read_json_options: ReadJsonOptions | None = None,
+        read_csv_options: ReadCSVOptions | None = None,
     ):
         ...
 ```
@@ -425,7 +433,7 @@ export FILESYSTEM_BLOCK_NAME="my_s3_block"
 
 Developers can extend the functionality of `mad_prefect` by:
 
-- **Adding Support for Additional File Types:** Extend `DataArtifact` and `DataArtifactQuery` to handle more file formats (e.g., CSV, Avro).
+- **Adding Support for Additional File Types:** Extend `DataArtifact` and `DataArtifactQuery` to handle more file formats (e.g., Avro).
 - **Custom Persistence Strategies:** Implement new methods in `DataArtifact` for persisting data using different storage mechanisms.
 - **Enhanced Filesystem Features:** Extend `FsspecFileSystem` with additional methods or support for more complex storage options.
 - **Integrate with Other Databases:** Adapt the querying capabilities to work with databases other than DuckDB if needed.

--- a/mad_prefect/data_assets/__init__.py
+++ b/mad_prefect/data_assets/__init__.py
@@ -2,10 +2,10 @@ import datetime
 import os
 from typing import Callable, Literal
 
-from mad_prefect.data_assets.options import ReadJsonOptions
+from mad_prefect.data_assets.options import ReadJsonOptions, ReadCSVOptions
 
 ASSET_METADATA_LOCATION = os.getenv("ASSET_METADATA_LOCATION", "_asset_metadata")
-ARTIFACT_FILE_TYPES = Literal["parquet", "json"]
+ARTIFACT_FILE_TYPES = Literal["parquet", "json", "csv"]
 
 
 def asset(
@@ -15,6 +15,7 @@ def asset(
     snapshot_artifacts: bool = False,
     artifact_filetype: ARTIFACT_FILE_TYPES = "json",
     read_json_options: ReadJsonOptions | None = None,
+    read_csv_options: ReadCSVOptions | None = None,
     cache_expiration: datetime.timedelta | None = None,
 ):
     # Prevent a circular reference as it references the env variable
@@ -29,6 +30,7 @@ def asset(
             snapshot_artifacts,
             artifact_filetype,
             read_json_options,
+            read_csv_options,
             cache_expiration,
         )
 

--- a/mad_prefect/data_assets/data_artifact_collector.py
+++ b/mad_prefect/data_assets/data_artifact_collector.py
@@ -1,5 +1,5 @@
 from mad_prefect.data_assets import ARTIFACT_FILE_TYPES
-from mad_prefect.data_assets.options import ReadJsonOptions
+from mad_prefect.data_assets.options import ReadCSVOptions, ReadJsonOptions
 from mad_prefect.data_assets.utils import yield_data_batches
 from mad_prefect.data_assets.data_artifact import DataArtifact
 
@@ -13,12 +13,14 @@ class DataArtifactCollector:
         filetype: ARTIFACT_FILE_TYPES = "json",
         artifacts: list[DataArtifact] | None = None,
         read_json_options: ReadJsonOptions | None = None,
+        read_csv_options: ReadCSVOptions | None = None,
     ):
         self.collector = collector
         self.dir = dir
         self.filetype = filetype
         self.artifacts = artifacts or []
         self.read_json_options = read_json_options or ReadJsonOptions()
+        self.read_csv_options = read_csv_options or ReadCSVOptions()
 
     async def collect(self):
         fragment_num = 0
@@ -30,7 +32,9 @@ class DataArtifactCollector:
                 fragment_artifact = fragment
             else:
                 path = self._build_artifact_path(self.dir, fragment_number=fragment_num)
-                fragment_artifact = DataArtifact(path, fragment, self.read_json_options)
+                fragment_artifact = DataArtifact(
+                    path, fragment, self.read_json_options, self.read_csv_options
+                )
 
             if await fragment_artifact.persist():
                 self.artifacts.append(fragment_artifact)

--- a/mad_prefect/data_assets/data_artifact_query.py
+++ b/mad_prefect/data_assets/data_artifact_query.py
@@ -137,21 +137,20 @@ class DataArtifactQuery:
 
         # Build the base options dict without 'columns'
         base_options = self.read_csv_options.model_dump(
-            exclude={"columns"},
             exclude_none=True,
         )
 
-        raise ValueError("INCOMPLETE FUNCTION: FINISH BEFORE COMMITTING")
-
         options_str = self._format_options_dict(base_options)
 
-        # Build a query that selects all from the CSV data
-        artifact_base_query = (
+        # Build the base query string without 'columns'
+        base_query = (
             f"SELECT * FROM read_csv({globs_formatted}, {options_str})"
+            if options_str
+            else f"SELECT * FROM read_csv({globs_formatted})"
         )
 
-        # Execute the query and return the DuckDB result
-        artifact_query = duckdb.query(artifact_base_query)
+        # Execute the query
+        artifact_query = duckdb.query(base_query)
         return artifact_query
 
     def _format_options_dict(self, options_dict: dict) -> str:

--- a/mad_prefect/data_assets/data_asset.py
+++ b/mad_prefect/data_assets/data_asset.py
@@ -3,7 +3,7 @@ import hashlib
 import inspect
 import json
 import re
-from typing import Callable
+from typing import Callable, List
 import duckdb
 from mad_prefect.data_assets import ARTIFACT_FILE_TYPES
 from mad_prefect.data_assets import ASSET_METADATA_LOCATION
@@ -51,6 +51,9 @@ class DataAsset:
 
         self.read_json_options = read_json_options or ReadJsonOptions()
         self.read_csv_options = read_csv_options or ReadCSVOptions()
+
+        # Extract and set filetypes for result artifacts
+        self.result_artifact_filetypes = self.get_result_artifact_filetypes()
 
         # If the function has no parameters, bind empty arguments immediately
         if not self._fn_signature.parameters:
@@ -160,18 +163,23 @@ class DataAsset:
                     )
 
         assert self._bound_arguments
-        result_artifact = self._create_result_artifact()
+
+        # There may be multiple result artifacts if following syntax is used "bronze/customers.parquet|csv"
+        self.result_artifacts = self._create_result_artifacts()
+
+        # primary_result_artifact will always be the first listed filetype
+        primary_result_artifact = self.result_artifacts[0]
 
         # Prevent asset from being rematerialized inside a single session
         if self.asset_run and (materialized := self.asset_run.materialized):
-            return result_artifact
+            return primary_result_artifact
 
         self.asset_run.runtime = datetime.now(UTC)
         self.last_materialized = await self._get_last_materialized()
 
         # If data has been materialized within cache_expiration period return empty result_artifact
-        if await self._cached_result(result_artifact, self.asset_run.runtime):
-            return result_artifact
+        if await self._cached_result(primary_result_artifact, self.asset_run.runtime):
+            return primary_result_artifact
 
         # Regenerate asset_run_id as runtime has now been set.
         self.asset_run.id = self._generate_asset_iteration_guid()
@@ -210,10 +218,19 @@ class DataAsset:
         )
 
         # The result is all the artifacts unioned
-        result_artifact.data = await artifact_query.query()
+        result_artifact_data = await artifact_query.query()
 
-        # Persist the result artifact to storage, fully materialize it
-        await result_artifact.persist()
+        for result_artifact in self.result_artifacts:
+            result_artifact.data = result_artifact_data
+
+            # Persist the result artifact to storage, fully materialize it
+            await result_artifact.persist()
+
+        # Release reference to data
+        result_artifact_data = None
+
+        # Reset primary_result_artifact after data assignment
+        primary_result_artifact = self.result_artifacts[0]
 
         # Record information about the run
         self.asset_run.materialized = datetime.now(UTC)
@@ -226,14 +243,21 @@ class DataAsset:
             f"Completed operations for asset_run_id: {self.asset_run.id}, on asset_id: {self.id}, on asset: {self.name}"
         )
 
-        return result_artifact
+        return primary_result_artifact
 
-    def _create_result_artifact(self):
-        return DataArtifact(
-            self.path,
-            read_json_options=self.read_json_options,
-            read_csv_options=self.read_csv_options,
-        )
+    def _create_result_artifacts(self) -> List[DataArtifact]:
+        base_path = self.path.split(".")[0]
+        result_artifacts = []
+        for filetype in self.result_artifact_filetypes:
+            result_artifacts.append(
+                DataArtifact(
+                    f"{base_path}.{filetype}",
+                    read_json_options=self.read_json_options,
+                    read_csv_options=self.read_csv_options,
+                )
+            )
+
+        return result_artifacts
 
     async def query(self, query_str: str | None = None):
         result_artifact = await self()
@@ -322,3 +346,7 @@ class DataAsset:
                 f"Retrieving cached result_artifact for asset_id: {self.id} | asset: {self.name}"
             )
             return True
+
+    def get_result_artifact_filetypes(self) -> List[str]:
+        filetypes_part = self.path.split(".")[-1]
+        return filetypes_part.split("|")

--- a/mad_prefect/data_assets/options.py
+++ b/mad_prefect/data_assets/options.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 
 class ReadJsonOptions(BaseModel):
@@ -23,3 +23,50 @@ class ReadJsonOptions(BaseModel):
     ignore_errors: Optional[bool] = None
     maximum_depth: Optional[int] = None
     records: Optional[str] = None
+
+
+class ReadCSVOptions(BaseModel):
+    hive_partitioning: Optional[bool] = True
+    union_by_name: Optional[bool] = True
+    header: Optional[bool] = True
+    auto_detect: Optional[bool] = True
+
+    # Below are all other DuckDB read_csv parameters,
+    # defaulting to None so that DuckDB's built-in defaults apply.
+    all_varchar: Optional[bool] = None
+    allow_quoted_nulls: Optional[bool] = None
+    auto_type_candidates: Optional[List[str]] = None
+    buffer_size: Optional[int] = None
+    columns: Optional[Dict[str, str]] = None
+    comment: Optional[str] = None
+    compression: Optional[str] = None
+    dateformat: Optional[str] = None
+    decimal_separator: Optional[str] = None
+    delim: Optional[str] = None
+    escape: Optional[str] = None
+    encoding: Optional[str] = None
+    filename: Optional[bool] = None
+    force_not_null: Optional[List[str]] = None
+    ignore_errors: Optional[bool] = None
+    max_line_size: Optional[int] = None
+    column_names: Optional[List[str]] = None
+    new_line: Optional[str] = None
+    normalize_names: Optional[bool] = None
+    null_padding: Optional[bool] = None
+    nullstr: Optional[Union[str, List[str]]] = None
+    null: Optional[Union[str, List[str]]] = None
+    parallel: Optional[bool] = None
+    quote: Optional[str] = None
+    rejects_scan: Optional[str] = None
+    rejects_table: Optional[str] = None
+    rejects_limit: Optional[int] = None
+    rfc_4180: Optional[bool] = None
+    sample_size: Optional[int] = None
+    sep: Optional[str] = None
+    skip: Optional[int] = None
+    store_rejects: Optional[bool] = None
+    timestampformat: Optional[str] = None
+    timestamp_format: Optional[str] = None
+    types: Optional[Union[List[str], Dict[str, str]]] = None
+    dtypes: Optional[Union[List[str], Dict[str, str]]] = None
+    column_types: Optional[Union[List[str], Dict[str, str]]] = None

--- a/tests/data_assets/test_data_asset_materialization.py
+++ b/tests/data_assets/test_data_asset_materialization.py
@@ -459,3 +459,36 @@ async def test_csv_artifacts_with_hive_partitions():
 
     assert "year" in csv_columns
     assert "month" in csv_columns
+
+
+async def test_multiple_result_artifacts():
+    @asset(
+        path="test_multiple_result_artifacts.parquet|csv|json",
+    )
+    async def multi_format_asset():
+        # Yield a single batch of data
+        yield [
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 25},
+        ]
+
+    # Call the assets
+    primary_result_artifact = await multi_format_asset()
+    assert primary_result_artifact
+
+    # Access the list of result artifacts via the attribute
+    result_artifacts = multi_format_asset.result_artifacts
+    assert result_artifacts
+    assert len(result_artifacts) == 3
+
+    # Directly assert the paths for each artifact
+    assert result_artifacts[0].path == "test_multiple_result_artifacts.parquet"
+    assert result_artifacts[1].path == "test_multiple_result_artifacts.csv"
+    assert result_artifacts[2].path == "test_multiple_result_artifacts.json"
+
+    # Query the primary result artifact
+    primary_query = await primary_result_artifact.query("SELECT COUNT(*) c")
+    assert primary_query
+
+    count_result = primary_query.fetchone()
+    assert count_result[0] == 2


### PR DESCRIPTION
User Story: “As a developer, I want to be able to save my data assets as both parquet and csv”

- Functionality for writing intermediate and result artifacts to CSV.
- Functionality added to allow |-delimited filetypes to the path parameter e.g. "path/to/file.parquet|csv" to produce multiple result artifacts.