### PR TITLE
fix: resolve path templated values before resolving artifact filetypes from path string

### DIFF
--- a/mad_prefect/data_assets/data_asset.py
+++ b/mad_prefect/data_assets/data_asset.py
@@ -52,9 +52,6 @@ class DataAsset:
         self.read_json_options = read_json_options or ReadJsonOptions()
         self.read_csv_options = read_csv_options or ReadCSVOptions()
 
-        # Extract and set filetypes for result artifacts
-        self.result_artifact_filetypes = self.get_result_artifact_filetypes()
-
         # If the function has no parameters, bind empty arguments immediately
         if not self._fn_signature.parameters:
             self._bind_arguments()
@@ -163,6 +160,9 @@ class DataAsset:
                     )
 
         assert self._bound_arguments
+
+        # Extract and set filetypes for result artifacts
+        self.result_artifact_filetypes = self.get_result_artifact_filetypes()
 
         # There may be multiple result artifacts if following syntax is used "bronze/customers.parquet|csv"
         self.result_artifacts = self._create_result_artifacts()

--- a/tests/data_assets/test_data_asset_materialization.py
+++ b/tests/data_assets/test_data_asset_materialization.py
@@ -7,7 +7,7 @@ from mad_prefect.data_assets import asset
 from mad_prefect.data_assets.data_asset import DataAsset
 from datetime import datetime, date
 import pandas as pd
-
+from pydantic import BaseModel
 from mad_prefect.data_assets.options import ReadJsonOptions
 
 
@@ -492,3 +492,21 @@ async def test_multiple_result_artifacts():
 
     count_result = primary_query.fetchone()
     assert count_result[0] == 2
+
+
+async def test_filetype_resolution():
+    class Asset(BaseModel):
+        path: str
+
+    @asset(path="{asset.path}")
+    async def path_resolution_asset(asset: Asset):
+        return [
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 25},
+        ]
+
+    path_asset_class_obj = Asset(path="path_resolution_asset.parquet|csv")
+
+    path_asset = path_resolution_asset.with_arguments(path_asset_class_obj)
+
+    return await path_asset()


### PR DESCRIPTION
Updated order resolution so that result_artifact_filetypes is set after bind_arguments has been applied