### PR TITLE
feat: create EnvBlock class to automatically load API credentials from a Prefect Block or environment variables

### DIFF
--- a/mad_prefect/envblock.py
+++ b/mad_prefect/envblock.py
@@ -2,25 +2,65 @@ from typing import Any, Dict, Type, ClassVar, Optional, TypeVar
 from prefect.blocks.core import Block
 import inspect
 import os
-
 from pydantic import SecretStr
+
 
 T = TypeVar("T", bound="EnvBlock")
 
 
 class EnvBlock(Block):
+    # Optional prefix to customize environment variable names
     prefix: ClassVar[Optional[str]] = None
+
+    # Singleton instance cache
     _instance: ClassVar[Optional[Any]] = None
 
     @classmethod
     async def from_env(cls: Type[T]) -> T:
+        """
+        Load an instance of the subclass from environment variables.
+
+        If the environment variable `<PREFIX>_CREDENTIAL_BLOCK_NAME` is set, the method
+        loads the corresponding Prefect block using `cls.load()` and returns it.
+
+        Otherwise, this method inspects the subclass's annotated attributes and attempts
+        to construct the instance by reading each attribute's value from environment variables.
+        Each environment variable must be named `<PREFIX>_<ATTRIBUTE>`, where `PREFIX` is
+        either the class-level `prefix` or the subclass name, uppercased.
+
+        Values are cast to the annotated types, including support for `SecretStr`. If a required
+        environment variable is missing and no default is defined in the subclass, a `ValueError`
+        is raised. The result is cached and reused on subsequent calls.
+
+        Example:
+            For a subclass `MyCreds`:
+
+                class MyCreds(EnvBlock):
+                    token: str
+                    url: str
+
+            Set the environment variables:
+                MYCREDS_TOKEN=abc123
+                MYCREDS_URL=https://example.com
+
+            Then call:
+                creds = await MyCreds.from_env()
+
+        Returns:
+            An instance of the subclass with attributes populated from environment variables.
+
+        Raises:
+            ValueError: If a required environment variable is missing or cannot
+            be converted to the expected type.
+        """
+        # Return cached instance if already created
         if cls._instance is not None:
             return cls._instance
 
-        # Use the subclass signature to access default values.
+        # Introspect the subclass to access declared fields and defaults
         sig = inspect.signature(cls)
 
-        # If prefix attribute exists in subclass use this as cls.prefix else use subclass name
+        # Determine the prefix: use 'prefix' class attribute if set in the subclass, or default to the class name
         downstream_prefix_param = sig.parameters.get("prefix")
         downstream_prefix = (
             downstream_prefix_param.default
@@ -28,28 +68,29 @@ class EnvBlock(Block):
             and downstream_prefix_param.default is not inspect.Parameter.empty
             else None
         )
-
         cls.prefix = downstream_prefix or cls.__name__
-
         normalized_prefix = cls.prefix.upper()  # type: ignore
 
-        # Check for a pre-registered block name from the environment.
+        # Attempt to load a Prefect block by name from an environment variable
         block_name = os.getenv(f"{normalized_prefix}_CREDENTIAL_BLOCK_NAME")
         if block_name is not None:
             block = await cls.load(block_name)  # type: ignore
             cls._instance = block
             return block
 
+        # Otherwise, construct the block from environment variables
         field_values: Dict[str, Any] = {}
 
         for field, field_type in cls.__annotations__.items():
+            # Skip private/internal fields
             if field.startswith("_"):
                 continue
 
+            # Form the expected environment variable name
             env_var = f"{normalized_prefix}_{field.upper()}"
             raw_value = os.getenv(env_var)
 
-            # If the env var is missing, try to use the default value from the signature.
+            # Use class-level default if env var is not set
             if raw_value is None:
                 param = sig.parameters.get(field)
                 if param is not None and param.default is not inspect.Parameter.empty:
@@ -58,8 +99,8 @@ class EnvBlock(Block):
                 else:
                     raise ValueError(f"Environment variable {env_var} is required.")
 
+            # Convert raw string to the appropriate type
             try:
-                # Convert to SecretStr if needed; otherwise, convert using the type.
                 if field_type == SecretStr:
                     field_values[field] = SecretStr(raw_value)
                 else:
@@ -69,6 +110,7 @@ class EnvBlock(Block):
                     f"Error converting {env_var} value '{raw_value}' to {field_type}: {e}"
                 )
 
+        # Instantiate and cache the block
         instance = cls(**field_values)
         cls._instance = instance
         return instance

--- a/mad_prefect/envblock.py
+++ b/mad_prefect/envblock.py
@@ -67,13 +67,13 @@ class EnvBlock(Block):
         - Otherwise fallback to class name
         - Returned value is upper cased
         """
-        downstream_schema = cls.model_fields
-        downstream_prefix_field = downstream_schema.get("prefix")
-        downstream_prefix_default = (
-            downstream_prefix_field.default if downstream_prefix_field else None
+        model_fields = cls.model_fields
+        prefix_field = model_fields.get("prefix")
+        default_prefix = (
+            prefix_field.default if prefix_field else None
         )
 
-        prefix = downstream_prefix_default or cls.__name__
+        prefix = default_prefix or cls.__name__
         return prefix.upper()
 
     @classmethod

--- a/mad_prefect/envblock.py
+++ b/mad_prefect/envblock.py
@@ -1,8 +1,20 @@
-from typing import Any, Dict, Type, ClassVar, Optional, TypeVar
+import types
+from typing import (
+    Any,
+    Dict,
+    Type,
+    ClassVar,
+    Optional,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 from prefect.blocks.core import Block
-import inspect
 import os
 from pydantic import SecretStr
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 
 T = TypeVar("T", bound="EnvBlock")
@@ -15,8 +27,57 @@ class EnvBlock(Block):
     # Singleton instance cache
     _instance: ClassVar[Optional[Any]] = None
 
+    @staticmethod
+    def retrieve_default_value(model_field: FieldInfo, env_var_name: str) -> Any:
+        if model_field.default not in (None, PydanticUndefined):
+            return model_field.default
+        if not model_field.is_required():
+            return None
+        raise ValueError(f"Environment variable {env_var_name} is required.")
+
+    @staticmethod
+    def unwrap_types(field_type: Any) -> list[type]:
+        origin = get_origin(field_type)
+        args = get_args(field_type)
+
+        if origin in (Union, types.UnionType):
+            return [t for t in args if t is not type(None)]
+        return [field_type]
+
+    @staticmethod
+    def apply_field_type(
+        raw_value: str, field_types: list[type], env_var_name: str
+    ) -> Any:
+        for possible_type in field_types:
+            try:
+                if possible_type == SecretStr:
+                    return SecretStr(raw_value)
+                return possible_type(raw_value)
+            except Exception:
+                continue
+        raise ValueError(
+            f"Error converting {env_var_name} value to any of {field_types}"
+        )
+
     @classmethod
-    async def from_env(cls: Type[T]) -> T:
+    def resolve_prefix(cls) -> str:
+        """
+        Returns the resolved prefix for the subclass:
+        - Use subclass-defined prefix if present
+        - Otherwise fallback to class name
+        - Returned value is upper cased
+        """
+        downstream_schema = cls.model_fields
+        downstream_prefix_field = downstream_schema.get("prefix")
+        downstream_prefix_default = (
+            downstream_prefix_field.default if downstream_prefix_field else None
+        )
+
+        prefix = downstream_prefix_default or cls.__name__
+        return prefix.upper()
+
+    @classmethod
+    async def from_env(cls: Type[T], env_vars: Optional[dict[str, str]] = None) -> T:
         """
         Load an instance of the subclass from environment variables.
 
@@ -57,22 +118,14 @@ class EnvBlock(Block):
         if cls._instance is not None:
             return cls._instance
 
-        # Introspect the subclass to access declared fields and defaults
-        sig = inspect.signature(cls)
+        # If no env_vars dict passed in use os.environ
+        if env_vars is None:
+            env_vars = dict(os.environ)
 
-        # Determine the prefix: use 'prefix' class attribute if set in the subclass, or default to the class name
-        downstream_prefix_param = sig.parameters.get("prefix")
-        downstream_prefix = (
-            downstream_prefix_param.default
-            if downstream_prefix_param is not None
-            and downstream_prefix_param.default is not inspect.Parameter.empty
-            else None
-        )
-        cls.prefix = downstream_prefix or cls.__name__
-        normalized_prefix = cls.prefix.upper()  # type: ignore
+        resolved_prefix = cls.resolve_prefix()
 
         # Attempt to load a Prefect block by name from an environment variable
-        block_name = os.getenv(f"{normalized_prefix}_CREDENTIAL_BLOCK_NAME")
+        block_name = env_vars.get(f"{resolved_prefix}_CREDENTIAL_BLOCK_NAME")
         if block_name is not None:
             block = await cls.load(block_name)  # type: ignore
             cls._instance = block
@@ -81,33 +134,27 @@ class EnvBlock(Block):
         # Otherwise, construct the block from environment variables
         field_values: Dict[str, Any] = {}
 
-        for field, field_type in cls.__annotations__.items():
+        for field, model_field in cls.model_fields.items():
             # Skip private/internal fields
             if field.startswith("_"):
                 continue
 
             # Form the expected environment variable name
-            env_var = f"{normalized_prefix}_{field.upper()}"
-            raw_value = os.getenv(env_var)
+            env_var_name = f"{resolved_prefix}_{field.upper()}"
+            raw_value = env_vars.get(env_var_name)
 
             # Use class-level default if env var is not set
             if raw_value is None:
-                param = sig.parameters.get(field)
-                if param is not None and param.default is not inspect.Parameter.empty:
-                    field_values[field] = param.default
-                    continue
-                else:
-                    raise ValueError(f"Environment variable {env_var} is required.")
+                field_values[field] = cls.retrieve_default_value(
+                    model_field, env_var_name
+                )
 
-            # Convert raw string to the appropriate type
-            try:
-                if field_type == SecretStr:
-                    field_values[field] = SecretStr(raw_value)
-                else:
-                    field_values[field] = field_type(raw_value)
-            except Exception as e:
-                raise ValueError(
-                    f"Error converting {env_var} value '{raw_value}' to {field_type}: {e}"
+            # Else cast the raw_value to the appropriate type
+            else:
+                # Extract the possible field types
+                field_types = cls.unwrap_types(model_field.annotation)
+                field_values[field] = cls.apply_field_type(
+                    raw_value, field_types, env_var_name
                 )
 
         # Instantiate and cache the block

--- a/mad_prefect/envblock.py
+++ b/mad_prefect/envblock.py
@@ -1,0 +1,74 @@
+from typing import Any, Dict, Type, ClassVar, Optional, TypeVar
+from prefect.blocks.core import Block
+import inspect
+import os
+
+from pydantic import SecretStr
+
+T = TypeVar("T", bound="EnvBlock")
+
+
+class EnvBlock(Block):
+    prefix: ClassVar[Optional[str]] = None
+    _instance: ClassVar[Optional[Any]] = None
+
+    @classmethod
+    async def from_env(cls: Type[T]) -> T:
+        if cls._instance is not None:
+            return cls._instance
+
+        # Use the subclass signature to access default values.
+        sig = inspect.signature(cls)
+
+        # If prefix attribute exists in subclass use this as cls.prefix else use subclass name
+        downstream_prefix_param = sig.parameters.get("prefix")
+        downstream_prefix = (
+            downstream_prefix_param.default
+            if downstream_prefix_param is not None
+            and downstream_prefix_param.default is not inspect.Parameter.empty
+            else None
+        )
+
+        cls.prefix = downstream_prefix or cls.__name__
+
+        normalized_prefix = cls.prefix.upper()  # type: ignore
+
+        # Check for a pre-registered block name from the environment.
+        block_name = os.getenv(f"{normalized_prefix}_CREDENTIAL_BLOCK_NAME")
+        if block_name is not None:
+            block = await cls.load(block_name)  # type: ignore
+            cls._instance = block
+            return block
+
+        field_values: Dict[str, Any] = {}
+
+        for field, field_type in cls.__annotations__.items():
+            if field.startswith("_"):
+                continue
+
+            env_var = f"{normalized_prefix}_{field.upper()}"
+            raw_value = os.getenv(env_var)
+
+            # If the env var is missing, try to use the default value from the signature.
+            if raw_value is None:
+                param = sig.parameters.get(field)
+                if param is not None and param.default is not inspect.Parameter.empty:
+                    field_values[field] = param.default
+                    continue
+                else:
+                    raise ValueError(f"Environment variable {env_var} is required.")
+
+            try:
+                # Convert to SecretStr if needed; otherwise, convert using the type.
+                if field_type == SecretStr:
+                    field_values[field] = SecretStr(raw_value)
+                else:
+                    field_values[field] = field_type(raw_value)
+            except Exception as e:
+                raise ValueError(
+                    f"Error converting {env_var} value '{raw_value}' to {field_type}: {e}"
+                )
+
+        instance = cls(**field_values)
+        cls._instance = instance
+        return instance

--- a/tests/test_env_block.py
+++ b/tests/test_env_block.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional, Union
 import pytest
 from pydantic import SecretStr
 from mad_prefect.envblock import EnvBlock
@@ -189,8 +190,8 @@ async def test_union_field_casting_with_optional():
         prefix: str = "UnionTest"
         retries: int | str  # Union[int, str]
         region: None | str  # Optional[str]
-        token: str
-        url: str
+        token: Optional[str]
+        url: Union[str, int]
         secret: SecretStr
 
     test_env = {

--- a/tests/test_env_block.py
+++ b/tests/test_env_block.py
@@ -27,71 +27,88 @@ def reset_env_and_instance(cls):
 
 
 async def test_loads_env_values():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "shhh"
+    DownstreamAPI._instance = None
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_URL": "https://x.com",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+    }
 
-    creds = await DownstreamAPI.from_env()
+    creds = await DownstreamAPI.from_env(test_env)
     assert creds.token == "abc"
     assert creds.url == "https://x.com"
-    assert creds.retries == 3
     assert isinstance(creds.secret, SecretStr)
     assert creds.secret.get_secret_value() == "shhh"
 
 
 async def test_uses_default_value():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "s3cr3t"
+    DownstreamAPI._instance = None
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_URL": "https://x.com",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+    }
 
-    creds = await DownstreamAPI.from_env()
+    creds = await DownstreamAPI.from_env(test_env)
     assert creds.retries == 3
 
 
 async def test_missing_required_field_raises():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "s3cr3t"
+    DownstreamAPI._instance = None
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+    }
 
     with pytest.raises(ValueError, match="DOWNSTREAMAPI_URL is required"):
-        await DownstreamAPI.from_env()
+        await DownstreamAPI.from_env(test_env)
 
 
 async def test_skips_internal_fields():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "shh"
-    os.environ["DOWNSTREAMAPI__INTERNAL"] = "hacked"
+    DownstreamAPI._instance = None
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_URL": "https://x.com",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+        "DOWNSTREAMAPI__INTERNAL": "hacked",
+    }
 
-    block = await DownstreamAPI.from_env()
+    block = await DownstreamAPI.from_env(test_env)
     assert block.token == "abc"
     assert block._internal == "should not load"  # not overridden
 
 
 async def test_instance_cached():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "url"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "s"
+    DownstreamAPI._instance = None
 
-    a = await DownstreamAPI.from_env()
-    b = await DownstreamAPI.from_env()
+    test_env_a = {
+        "DOWNSTREAMAPI_TOKEN": "a",
+        "DOWNSTREAMAPI_URL": "a",
+        "DOWNSTREAMAPI_SECRET": "a",
+    }
+
+    test_env_b = {
+        "DOWNSTREAMAPI_TOKEN": "b",
+        "DOWNSTREAMAPI_URL": "b",
+        "DOWNSTREAMAPI_SECRET": "b",
+    }
+
+    a = await DownstreamAPI.from_env(test_env_a)
+    b = await DownstreamAPI.from_env(test_env_b)
     assert a is b
 
 
 async def test_loads_block_if_env_name_provided():
+    DownstreamAPI._instance = None
+
     class FakeBlock(DownstreamAPI):
         @classmethod
         async def load(cls, name):
             return cls(token="loaded", url="https://loaded", secret=SecretStr("lol"))
 
-    reset_env_and_instance(FakeBlock)
-    os.environ["FAKEBLOCK_CREDENTIAL_BLOCK_NAME"] = "something"
+    test_env = {"FAKEBLOCK_CREDENTIAL_BLOCK_NAME": "something"}
 
-    result = await FakeBlock.from_env()
+    result = await FakeBlock.from_env(test_env)
     assert result.token == "loaded"
 
 
@@ -121,35 +138,39 @@ async def test_subclass_with_explicit_prefix():
         prefix: str = "CustomPrefix"
         token: str
 
-    reset_env_and_instance(ConfiguredPrefix)
-    os.environ["CUSTOMPREFIX_TOKEN"] = "expected"
-    os.environ["CONFIGUREDPREFIX_TOKEN"] = "should_be_ignored"
+    test_env = {
+        "CUSTOMPREFIX_TOKEN": "expected",
+        "CONFIGUREDPREFIX_TOKEN": "should_be_ignored",
+    }
 
-    block = await ConfiguredPrefix.from_env()
+    block = await ConfiguredPrefix.from_env(test_env)
     assert block.token == "expected"
 
 
 async def test_successful_casting_of_standard_type():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "shh"
-    os.environ["DOWNSTREAMAPI_RETRIES"] = "7"
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_URL": "https://x.com",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+        "DOWNSTREAMAPI_RETRIES": "7",
+    }
 
-    block = await DownstreamAPI.from_env()
+    block = await DownstreamAPI.from_env(test_env)
     assert block.retries == 7
     assert isinstance(block.retries, int)
 
 
 async def test_unsuccessful_casting_raises_value_error():
-    reset_env_and_instance(DownstreamAPI)
-    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
-    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
-    os.environ["DOWNSTREAMAPI_SECRET"] = "shh"
-    os.environ["DOWNSTREAMAPI_RETRIES"] = "notanint"
+    DownstreamAPI._instance = None
+    test_env = {
+        "DOWNSTREAMAPI_TOKEN": "abc",
+        "DOWNSTREAMAPI_URL": "https://x.com",
+        "DOWNSTREAMAPI_SECRET": "shhh",
+        "DOWNSTREAMAPI_RETRIES": "notanint",
+    }
 
     with pytest.raises(ValueError, match="DOWNSTREAMAPI_RETRIES.*int"):
-        await DownstreamAPI.from_env()
+        await DownstreamAPI.from_env(test_env)
 
 
 async def test_secretstr_field_is_wrapped_correctly():
@@ -161,3 +182,29 @@ async def test_secretstr_field_is_wrapped_correctly():
     block = await DownstreamAPI.from_env()
     assert isinstance(block.secret, SecretStr)
     assert block.secret.get_secret_value() == "supersecret"
+
+
+async def test_union_field_casting_with_optional():
+    class UnionBlock(EnvBlock):
+        prefix: str = "UnionTest"
+        retries: int | str  # Union[int, str]
+        region: None | str  # Optional[str]
+        token: str
+        url: str
+        secret: SecretStr
+
+    test_env = {
+        "UNIONTEST_RETRIES": "42",  # should cast to int
+        "UNIONTEST_REGION": "au-east",  # should remain as str
+        "UNIONTEST_TOKEN": "abc",
+        "UNIONTEST_URL": "https://x.com",
+        "UNIONTEST_SECRET": "shhh",
+    }
+
+    block = await UnionBlock.from_env(test_env)
+
+    assert isinstance(block.retries, int)
+    assert block.retries == 42
+
+    assert isinstance(block.region, str)
+    assert block.region == "au-east"

--- a/tests/test_env_block.py
+++ b/tests/test_env_block.py
@@ -1,0 +1,129 @@
+import os
+import pytest
+from pydantic import SecretStr
+from mad_prefect.envblock import EnvBlock
+
+
+class DownstreamAPI(EnvBlock):
+    token: str
+    url: str
+    retries: int = 3
+    secret: SecretStr
+    _internal: str = "should not load"
+
+
+def reset_env_and_instance(cls):
+    keys = [
+        "DOWNSTREAMAPI_TOKEN",
+        "DOWNSTREAMAPI_URL",
+        "DOWNSTREAMAPI_SECRET",
+        "DOWNSTREAMAPI_RETRIES",
+        "DOWNSTREAMAPI_CREDENTIAL_BLOCK_NAME",
+        "DOWNSTREAMAPI__INTERNAL",
+    ]
+    for key in keys:
+        os.environ.pop(key, None)
+    cls._instance = None
+
+
+async def test_loads_env_values():
+    reset_env_and_instance(DownstreamAPI)
+    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
+    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
+    os.environ["DOWNSTREAMAPI_SECRET"] = "shhh"
+
+    creds = await DownstreamAPI.from_env()
+    assert creds.token == "abc"
+    assert creds.url == "https://x.com"
+    assert creds.retries == 3
+    assert isinstance(creds.secret, SecretStr)
+    assert creds.secret.get_secret_value() == "shhh"
+
+
+async def test_uses_default_value():
+    reset_env_and_instance(DownstreamAPI)
+    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
+    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
+    os.environ["DOWNSTREAMAPI_SECRET"] = "s3cr3t"
+
+    creds = await DownstreamAPI.from_env()
+    assert creds.retries == 3
+
+
+async def test_missing_required_field_raises():
+    reset_env_and_instance(DownstreamAPI)
+    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
+    os.environ["DOWNSTREAMAPI_SECRET"] = "s3cr3t"
+
+    with pytest.raises(ValueError, match="DOWNSTREAMAPI_URL is required"):
+        await DownstreamAPI.from_env()
+
+
+async def test_skips_internal_fields():
+    reset_env_and_instance(DownstreamAPI)
+    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
+    os.environ["DOWNSTREAMAPI_URL"] = "https://x.com"
+    os.environ["DOWNSTREAMAPI_SECRET"] = "shh"
+    os.environ["DOWNSTREAMAPI__INTERNAL"] = "hacked"
+
+    block = await DownstreamAPI.from_env()
+    assert block.token == "abc"
+    assert block._internal == "should not load"  # not overridden
+
+
+async def test_instance_cached():
+    reset_env_and_instance(DownstreamAPI)
+    os.environ["DOWNSTREAMAPI_TOKEN"] = "abc"
+    os.environ["DOWNSTREAMAPI_URL"] = "url"
+    os.environ["DOWNSTREAMAPI_SECRET"] = "s"
+
+    a = await DownstreamAPI.from_env()
+    b = await DownstreamAPI.from_env()
+    assert a is b
+
+
+async def test_loads_block_if_env_name_provided():
+    class FakeBlock(DownstreamAPI):
+        @classmethod
+        async def load(cls, name):
+            return cls(token="loaded", url="https://loaded", secret=SecretStr("lol"))
+
+    reset_env_and_instance(FakeBlock)
+    os.environ["FAKEBLOCK_CREDENTIAL_BLOCK_NAME"] = "something"
+
+    result = await FakeBlock.from_env()
+    assert result.token == "loaded"
+
+
+async def test_instances_are_isolated_per_subclass():
+    class A(EnvBlock):
+        token: str
+
+    class B(EnvBlock):
+        token: str
+
+    reset_env_and_instance(A)
+    reset_env_and_instance(B)
+
+    os.environ["A_TOKEN"] = "aaa"
+    os.environ["B_TOKEN"] = "bbb"
+
+    a = await A.from_env()
+    b = await B.from_env()
+
+    assert a.token == "aaa"
+    assert b.token == "bbb"
+    assert a is not b
+
+
+async def test_subclass_with_explicit_prefix():
+    class ConfiguredPrefix(EnvBlock):
+        prefix: str = "CustomPrefix"
+        token: str
+
+    reset_env_and_instance(ConfiguredPrefix)
+    os.environ["CUSTOMPREFIX_TOKEN"] = "expected"
+    os.environ["CONFIGUREDPREFIX_TOKEN"] = "should_be_ignored"
+
+    block = await ConfiguredPrefix.from_env()
+    assert block.token == "expected"


### PR DESCRIPTION
### Add `EnvBlock` for loading Prefect blocks from environment variables

This PR introduces a reusable `EnvBlock` base class that enables Prefect block subclasses to be instantiated from environment variables, with support for:

- Automatic prefixing based on the class name or an explicit `prefix` class attribute
- Singleton instance caching
- Optional fallback to loading an existing block via `<PREFIX>_CREDENTIAL_BLOCK_NAME`
- Support for default values defined in the subclass
- Type casting based on annotated types, including `SecretStr`
- Ignoring private/internal attributes (those starting with `_`)

#### Example Usage

```python
class DownstreamAPI(EnvBlock):
    token: str
    url: str
    retries: int = 3
    secret: SecretStr
```

Environment variables:

```
DOWNSTREAMAPI_TOKEN=abc123
DOWNSTREAMAPI_URL=https://example.com
DOWNSTREAMAPI_SECRET=supersecret
```

```python
creds = await DownstreamAPI.from_env()
```

#### Test Coverage

Tests included for:

- Loading required and optional fields
- Respecting default values
- Failing on missing required variables
- Properly casting `SecretStr`
- Ignoring private fields (e.g., `_internal`)
- Handling class-level `prefix`
- Ensuring instance caching per subclass
- Supporting block load via `<PREFIX>_CREDENTIAL_BLOCK_NAME`

---

This allows seamless environment-driven configuration of blocks, especially useful in containerized deployments or CI pipelines.
