### PR TITLE
ci: make release flow PR-safe

### DIFF
--- a/.github/workflows/prepare-stable-release.yml
+++ b/.github/workflows/prepare-stable-release.yml
@@ -1,0 +1,90 @@
+name: prepare-stable-release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    # Branch strategy:
+    # - next stays automated for prerelease bumps, tags, releases, and PyPI publishing
+    # - main stays PR-only and is never mutated by CI
+    # - stable releases are finalized on a release branch and merged into main via PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out next with full history
+        uses: actions/checkout@v4
+        with:
+          ref: next
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: "x64"
+
+      - name: Install & configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
+
+      - name: Install release tooling
+        run: poetry install --no-interaction --only dev --no-root
+
+      - name: Derive stable release version
+        id: version
+        run: |
+          current_version="$(poetry version -s)"
+          stable_version="$(python -c 'import re, sys; print(re.sub(r"(?:(?:a|b|rc)\d+)$", "", sys.argv[1]))' "$current_version")"
+
+          if [ "$stable_version" = "$current_version" ]; then
+            echo "::error::Expected a prerelease version on next, found $current_version"
+            exit 1
+          fi
+
+          echo "current_version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "stable_version=$stable_version" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/stable-v$stable_version" >> "$GITHUB_OUTPUT"
+
+      - name: Finalize version files and changelog without tagging
+        run: |
+          poetry run cz bump "${{ steps.version.outputs.stable_version }}" \
+            --allow-no-commit \
+            --changelog \
+            --version-files-only \
+            --yes
+
+      - name: Open or update stable release PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            CHANGELOG.md
+            pyproject.toml
+          base: main
+          branch: ${{ steps.version.outputs.release_branch }}
+          commit-message: "bump: prepare stable release ${{ steps.version.outputs.stable_version }}"
+          title: "chore: prepare stable release ${{ steps.version.outputs.stable_version }}"
+          body: |
+            ## Summary
+            - finalize `${{ steps.version.outputs.current_version }}` as `${{ steps.version.outputs.stable_version }}`
+            - update `pyproject.toml` and `CHANGELOG.md` from `next` without creating a tag
+            - prepare the stable release as a PR into `main`
+
+            ## Release flow
+            - `next` continues to own prerelease bumps and publishing
+            - merging this PR into `main` lets `publish.yml` create the stable tag/release and publish to PyPI without mutating `main`
+          delete-branch: false
+          draft: false
+
+      - name: Report PR
+        run: |
+          echo "Stable release PR: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      revision: ${{ steps.next-release.outputs.revision || steps.main-release.outputs.revision }}
+      revision: ${{ steps.next_release.outputs.revision || steps.main_release.outputs.revision }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,18 +44,18 @@ jobs:
 
       - name: Capture prerelease revision
         if: github.ref == 'refs/heads/next'
-        id: next-release
+        id: next_release
         run: echo "revision=${{ steps.cz.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Read committed stable version
         if: github.ref == 'refs/heads/main'
-        id: committed-version
+        id: committed_version
         run: echo "revision=$(poetry version -s)" >> "$GITHUB_OUTPUT"
 
       - name: Extract stable release notes from CHANGELOG.md
         if: github.ref == 'refs/heads/main'
         env:
-          VERSION: ${{ steps.committed-version.outputs.revision }}
+          VERSION: ${{ steps.committed_version.outputs.revision }}
         run: |
           awk -v header="## ${VERSION} (" '
             index($0, header) == 1 { capture=1 }
@@ -70,8 +70,8 @@ jobs:
 
       - name: Capture stable revision
         if: github.ref == 'refs/heads/main'
-        id: main-release
-        run: echo "revision=${{ steps.committed-version.outputs.revision }}" >> "$GITHUB_OUTPUT"
+        id: main_release
+        run: echo "revision=${{ steps.committed_version.outputs.revision }}" >> "$GITHUB_OUTPUT"
 
       - name: Create prerelease GitHub release
         if: github.ref == 'refs/heads/next'
@@ -89,7 +89,7 @@ jobs:
         with:
           body_path: body.md
           prerelease: false
-          tag_name: ${{ steps.committed-version.outputs.revision }}
+          tag_name: ${{ steps.committed_version.outputs.revision }}
           target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,48 +3,94 @@ name: publish
 on:
   push:
     branches:
-      - main          # stable
-      - next          # prerelease
+      - main
+      - next
 
 jobs:
   release:
-    # expose the tag emitted by Commitizen so downstream jobs can
-    # check out the exact revision that was bumped
-    outputs:
-      tag: ${{ env.REVISION }}
+    # Branch strategy:
+    # - next: Commitizen may commit/tag prerelease bumps and update CHANGELOG.md
+    # - main: publish only from the version already merged via PR; never mutate main
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.next-release.outputs.revision || steps.main-release.outputs.revision }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # ──────────────── BUMP + CHANGELOG ────────────────
-      # next ➜ prerelease (rc), main ➜ normal
-      - name: "Bump (stable) & changelog"
+      - name: Setup Python
         if: github.ref == 'refs/heads/main'
-        uses: commitizen-tools/commitizen-action@0.21.0
+        uses: actions/setup-python@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          changelog_increment_filename: body.md
+          python-version: "3.11"
+          architecture: "x64"
 
-      - name: "Bump (prerelease) & changelog"
+      - name: Install Poetry
+        if: github.ref == 'refs/heads/main'
+        uses: snok/install-poetry@v1
+
+      - name: Bump prerelease version and changelog
         if: github.ref == 'refs/heads/next'
+        id: cz
         uses: commitizen-tools/commitizen-action@0.21.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           changelog_increment_filename: body.md
-          prerelease: rc            # alpha/beta/rc are valid :contentReference[oaicite:0]{index=0}
+          prerelease: rc
 
-      # ──────────────── GITHUB RELEASE ────────────────
-      - name: Create GitHub release
+      - name: Capture prerelease revision
+        if: github.ref == 'refs/heads/next'
+        id: next-release
+        run: echo "revision=${{ steps.cz.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Read committed stable version
+        if: github.ref == 'refs/heads/main'
+        id: committed-version
+        run: echo "revision=$(poetry version -s)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract stable release notes from CHANGELOG.md
+        if: github.ref == 'refs/heads/main'
+        env:
+          VERSION: ${{ steps.committed-version.outputs.revision }}
+        run: |
+          awk -v header="## ${VERSION} (" '
+            index($0, header) == 1 { capture=1 }
+            capture && /^## / && index($0, header) != 1 { exit }
+            capture { print }
+          ' CHANGELOG.md > body.md
+
+          test -s body.md || {
+            echo "::error::Missing changelog entry for ${VERSION}"
+            exit 1
+          }
+
+      - name: Capture stable revision
+        if: github.ref == 'refs/heads/main'
+        id: main-release
+        run: echo "revision=${{ steps.committed-version.outputs.revision }}" >> "$GITHUB_OUTPUT"
+
+      - name: Create prerelease GitHub release
+        if: github.ref == 'refs/heads/next'
         uses: softprops/action-gh-release@v2
         with:
           body_path: body.md
-          tag_name: ${{ env.REVISION }}
-          prerelease: ${{ github.ref == 'refs/heads/next' }}
+          tag_name: ${{ steps.cz.outputs.version }}
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create stable GitHub release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: body.md
+          prerelease: false
+          tag_name: ${{ steps.committed-version.outputs.revision }}
+          target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,13 +101,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release.outputs.tag }}
+          ref: ${{ needs.release.outputs.revision }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          architecture: 'x64'
+          python-version: "3.11"
+          architecture: "x64"
 
       - name: Install & configure Poetry
         uses: snok/install-poetry@v1
@@ -70,10 +116,10 @@ jobs:
           virtualenvs-in-project: true
           virtualenvs-path: .venv
           installer-parallel: true
-          
+
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
-          
+
       - name: Build
         run: poetry build
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -1,0 +1,35 @@
+# Release Flow
+
+## Summary
+- `next` remains the prerelease branch. Pushes there can bump `rc` versions, update `CHANGELOG.md`, create prerelease tags/releases, and publish to PyPI.
+- `main` remains PR-only. Pushes there read the already-committed stable version and changelog, create the stable tag/release, and publish to PyPI without pushing commits back to the branch.
+- Stable releases are prepared by `.github/workflows/prepare-stable-release.yml`, which opens or updates a PR from a generated release branch into `main`.
+
+## Usage
+- Prerelease automation still happens on a normal push to `next`.
+- Trigger a stable release prep run from GitHub Actions or with:
+
+```bash
+gh workflow run prepare-stable-release.yml --ref next
+```
+
+- Review the generated `release/stable-vX.Y.Z` PR into `main`.
+- Merge that PR when the stable release is ready. The `publish` workflow on `main` will tag, create the GitHub release, build, and publish from the committed stable version.
+
+## Operational Notes
+- Stable release prep derives the final version from the current prerelease, for example `2.3.0rc15 -> 2.3.0`.
+- The prep workflow uses `cz bump <stable-version> --allow-no-commit --changelog --version-files-only --yes` so `pyproject.toml` and `CHANGELOG.md` are updated without creating a tag before the PR is merged.
+- `CHANGELOG.md` remains the source of truth for published release notes.
+
+## Progress
+- [x] `publish.yml` keeps prerelease bumping on `next` and removes branch mutation from `main`.
+- [x] `prepare-stable-release.yml` prepares a stable version/changelog PR into `main`.
+- [x] Release-flow documentation added for developers operating the branch strategy.
+
+## Next Steps
+- Run the new `prepare-stable-release` workflow once after this change lands to verify repository permissions and branch naming in GitHub.
+- Consider adding `actionlint` to CI if workflow validation needs to become part of the automated test suite.
+
+## Blockers & Risks
+- Workflow behavior depends on `GITHUB_TOKEN` retaining permission to create tags/releases and to push the generated release-prep branch.
+- No repository unit tests exercise GitHub Actions YAML directly, so workflow correctness is validated by review plus action syntax checks and the first live run.


### PR DESCRIPTION
## Summary
- stop `publish.yml` from mutating `main` after merges
- keep automated prerelease bumps/releases on `next`
- add a `workflow_dispatch` stable-release prep flow that opens or updates a PR into `main`
- document the updated release branch strategy in `docs/release-flow.md`

## Why GH013 was happening
`publish.yml` currently runs `commitizen-tools/commitizen-action` on pushes to both `next` and `main`.

That action bumps the version, updates `CHANGELOG.md`, creates a tag, and pushes the generated commit back to the branch. On `main`, that means CI tries to write a post-merge bump commit with `GITHUB_TOKEN`. Because `main` is PR-only, GitHub rejects that direct branch mutation with `GH013`.

## New release flow
- `next` stays the prerelease branch. Pushes there still run Commitizen prerelease bumps (`rc`), update `CHANGELOG.md`, create prerelease releases/tags, build, and publish to PyPI.
- `main` is now publish-only. Pushes there read the already-committed stable version from the repo via `poetry version -s`, extract the matching changelog entry, create the stable tag/release at `github.sha`, build that revision, and publish to PyPI.
- `.github/workflows/prepare-stable-release.yml` prepares stable releases through a PR-safe path. It checks out `next`, converts the current prerelease version to the final stable version with Commitizen in `--version-files-only` mode, updates `pyproject.toml` and `CHANGELOG.md`, and opens or updates a PR into `main`.

## How to trigger a stable release now
1. Run the `prepare-stable-release` workflow from GitHub Actions.
2. Or trigger it with `gh workflow run prepare-stable-release.yml --ref next`.
3. Review and merge the generated `release/stable-vX.Y.Z` PR into `main`.
4. The normal `publish` workflow on `main` will then create the stable GitHub release/tag and publish to PyPI without pushing any commit back to `main`.

## Validation
- parsed `.github/workflows/publish.yml` and `.github/workflows/prepare-stable-release.yml` locally with PyYAML
- ran `git diff --check`
- did not run the repository test suite because this change only touches GitHub Actions/docs and there are no repo tests covering workflow execution